### PR TITLE
Upgrade Spring Boot from 3.5.5 to 3.5.9

### DIFF
--- a/section-12-spring-boot-3-quick-start/01-spring-boot-demo/pom.xml
+++ b/section-12-spring-boot-3-quick-start/01-spring-boot-demo/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.5.9</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot.demo</groupId>

--- a/section-13-spring-boot-3-rest-apis-quick-start/01-spring-boot-rest-crud-hello-world/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/01-spring-boot-rest-crud-hello-world/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.5.9</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-13-spring-boot-3-rest-apis-quick-start/02-spring-boot-rest-crud-students-list-base/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/02-spring-boot-rest-crud-students-list-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.5.9</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-13-spring-boot-3-rest-apis-quick-start/03-spring-boot-rest-crud-students-list-refactored/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/03-spring-boot-rest-crud-students-list-refactored/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.5.9</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-13-spring-boot-3-rest-apis-quick-start/04-spring-boot-rest-crud-students-path-variable-get-single-student/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/04-spring-boot-rest-crud-students-path-variable-get-single-student/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.5.9</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-14-spring-boot-3-spring-mvc-quick-start/01-thymeleafdemo-helloworld/pom.xml
+++ b/section-14-spring-boot-3-spring-mvc-quick-start/01-thymeleafdemo-helloworld/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.5.9</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/section-14-spring-boot-3-spring-mvc-quick-start/02-thymeleafdemo-helloworld-css/pom.xml
+++ b/section-14-spring-boot-3-spring-mvc-quick-start/02-thymeleafdemo-helloworld-css/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.5.9</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>


### PR DESCRIPTION
## Summary
- Updated all Spring Boot projects from version 3.5.5 to 3.5.9
- 7 pom.xml files updated across sections 12, 13, and 14

## Changes
- section-12-spring-boot-3-quick-start/01-spring-boot-demo
- section-13-spring-boot-3-rest-apis-quick-start (4 projects)
- section-14-spring-boot-3-spring-mvc-quick-start (2 projects)