### PR TITLE
Upgrade all Spring Boot projects from 3.5.9 to 4.0.1

### DIFF
--- a/section-12-spring-boot-3-quick-start/01-spring-boot-demo/pom.xml
+++ b/section-12-spring-boot-3-quick-start/01-spring-boot-demo/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.9</version>
+		<version>4.0.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot.demo</groupId>
@@ -20,12 +20,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/section-13-spring-boot-3-rest-apis-quick-start/01-spring-boot-rest-crud-hello-world/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/01-spring-boot-rest-crud-hello-world/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.9</version>
+		<version>4.0.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>
@@ -20,12 +20,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/section-13-spring-boot-3-rest-apis-quick-start/02-spring-boot-rest-crud-students-list-base/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/02-spring-boot-rest-crud-students-list-base/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.9</version>
+		<version>4.0.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>
@@ -20,12 +20,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/section-13-spring-boot-3-rest-apis-quick-start/03-spring-boot-rest-crud-students-list-refactored/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/03-spring-boot-rest-crud-students-list-refactored/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.9</version>
+		<version>4.0.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>
@@ -20,12 +20,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/section-13-spring-boot-3-rest-apis-quick-start/04-spring-boot-rest-crud-students-path-variable-get-single-student/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/04-spring-boot-rest-crud-students-path-variable-get-single-student/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.9</version>
+		<version>4.0.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>
@@ -20,12 +20,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/section-14-spring-boot-3-spring-mvc-quick-start/01-thymeleafdemo-helloworld/pom.xml
+++ b/section-14-spring-boot-3-spring-mvc-quick-start/01-thymeleafdemo-helloworld/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.9</version>
+		<version>4.0.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>
@@ -24,7 +24,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>
@@ -35,7 +35,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/section-14-spring-boot-3-spring-mvc-quick-start/02-thymeleafdemo-helloworld-css/pom.xml
+++ b/section-14-spring-boot-3-spring-mvc-quick-start/02-thymeleafdemo-helloworld-css/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.9</version>
+		<version>4.0.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>
@@ -24,7 +24,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>
@@ -35,7 +35,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
## Summary
Upgraded all 7 Spring Boot projects from version 3.5.9 to 4.0.1

## Changes Made

### POM Updates (All 7 Projects)
- Updated spring-boot-starter-parent from 3.5.9 to 4.0.1
- Replaced spring-boot-starter-web with spring-boot-starter-webmvc
- Replaced spring-boot-starter-test with spring-boot-starter-webmvc-test

### Additional Changes (Projects 6-7 only)
- Added spring-boot-starter-thymeleaf-test for Thymeleaf MVC projects

## Projects Updated
1. section-12-spring-boot-3-quick-start/01-spring-boot-demo
2. section-13-spring-boot-3-rest-apis-quick-start/01-spring-boot-rest-crud-hello-world
3. section-13-spring-boot-3-rest-apis-quick-start/02-spring-boot-rest-crud-students-list-base
4. section-13-spring-boot-3-rest-apis-quick-start/03-spring-boot-rest-crud-students-list-refactored
5. section-13-spring-boot-3-rest-apis-quick-start/04-spring-boot-rest-crud-students-path-variable-get-single-student
6. section-14-spring-boot-3-spring-mvc-quick-start/01-thymeleafdemo-helloworld
7. section-14-spring-boot-3-spring-mvc-quick-start/02-thymeleafdemo-helloworld-css

## Testing Completed
- All 7 projects build successfully with Maven
- Sample application startup tests verified
- No code changes required (Java code remains compatible)

## Java Compatibility
- Java 25 exceeds Spring Boot 4.0 minimum requirement (Java 17+)
- Already using jakarta.annotation.PostConstruct (not legacy javax)

## Breaking Changes
None - all Java code remains fully compatible with Spring Boot 4.0.1