### PR TITLE
Fix incorrect imports and add missing getNumberOfEnemies method in enemy versions 6-9

### DIFF
--- a/section-06-java-oop/battle-arena-sections/enemyversion6/src/main/java/oop/enemyversion6/Enemy.java
+++ b/section-06-java-oop/battle-arena-sections/enemyversion6/src/main/java/oop/enemyversion6/Enemy.java
@@ -71,4 +71,8 @@ public class Enemy implements IEnemy {
     @Override
     public int getId() {return id;}
 
+    public static int getNumberOfEnemies() {
+        return numberOfEnemies;
+    }
+
 }

--- a/section-06-java-oop/battle-arena-sections/enemyversion6/src/main/java/oop/enemyversion6/Implementation.java
+++ b/section-06-java-oop/battle-arena-sections/enemyversion6/src/main/java/oop/enemyversion6/Implementation.java
@@ -1,6 +1,6 @@
 package oop.enemyversion6;
 
-import static oop.enemyversion5.Enemy.getNumberOfEnemies;
+import static oop.enemyversion6.Enemy.getNumberOfEnemies;
 
 public class Implementation {
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion7/src/main/java/oop/enemyversion7/Enemy.java
+++ b/section-06-java-oop/battle-arena-sections/enemyversion7/src/main/java/oop/enemyversion7/Enemy.java
@@ -58,4 +58,8 @@ public abstract class Enemy implements IEnemy {
 
     public int getId() {return id;}
 
+    public static int getNumberOfEnemies() {
+        return numberOfEnemies;
+    }
+
 }

--- a/section-06-java-oop/battle-arena-sections/enemyversion7/src/main/java/oop/enemyversion7/Implementation.java
+++ b/section-06-java-oop/battle-arena-sections/enemyversion7/src/main/java/oop/enemyversion7/Implementation.java
@@ -1,6 +1,6 @@
 package oop.enemyversion7;
 
-import static oop.enemyversion5.Enemy.getNumberOfEnemies;
+import static oop.enemyversion7.Enemy.getNumberOfEnemies;
 
 public class Implementation {
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion8/src/main/java/oop/enemyversion8/Enemy.java
+++ b/section-06-java-oop/battle-arena-sections/enemyversion8/src/main/java/oop/enemyversion8/Enemy.java
@@ -71,4 +71,8 @@ public abstract class Enemy implements IEnemy {
 
     public int getId() {return id;}
 
+    public static int getNumberOfEnemies() {
+        return numberOfEnemies;
+    }
+
 }

--- a/section-06-java-oop/battle-arena-sections/enemyversion8/src/main/java/oop/enemyversion8/Implementation.java
+++ b/section-06-java-oop/battle-arena-sections/enemyversion8/src/main/java/oop/enemyversion8/Implementation.java
@@ -1,6 +1,6 @@
 package oop.enemyversion8;
 
-import static oop.enemyversion5.Enemy.getNumberOfEnemies;
+import static oop.enemyversion8.Enemy.getNumberOfEnemies;
 
 public class Implementation {
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion9/src/main/java/oop/enemyversion9/Implementation.java
+++ b/section-06-java-oop/battle-arena-sections/enemyversion9/src/main/java/oop/enemyversion9/Implementation.java
@@ -6,7 +6,7 @@ import oop.enemyversion9.enemies.individualenemy.Zombie;
 import oop.enemyversion9.heros.Hero;
 import oop.enemyversion9.heros.weapons.Weapon;
 
-import static oop.enemyversion5.Enemy.getNumberOfEnemies;
+import static oop.enemyversion9.enemies.Enemy.getNumberOfEnemies;
 
 public class Implementation {
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion9/src/main/java/oop/enemyversion9/enemies/Enemy.java
+++ b/section-06-java-oop/battle-arena-sections/enemyversion9/src/main/java/oop/enemyversion9/enemies/Enemy.java
@@ -59,4 +59,8 @@ public abstract class Enemy implements IEnemy {
 
     public int getId() {return id;}
 
+    public static int getNumberOfEnemies() {
+        return numberOfEnemies;
+    }
+
 }


### PR DESCRIPTION
## Summary
* Fix incorrect imports in Implementation.java for enemyversion6, 7, 8, 9
* Each version was importing from oop.enemyversion5 instead of its own package
* Add missing getNumberOfEnemies() static method to Enemy.java in all 4 versions
* Resolves compilation errors in GitHub Actions build

## Changes
* enemyversion6: Fixed import to use oop.enemyversion6, added getter method
* enemyversion7: Fixed import to use oop.enemyversion7, added getter method
* enemyversion8: Fixed import to use oop.enemyversion8, added getter method
* enemyversion9: Fixed import to use oop.enemyversion9.enemies, added getter method

## Test plan
* Verify mvn clean compile succeeds for all 4 projects
* Verify GitHub Actions build passes for Section 06