### PR TITLE
feat: add .gitattributes to Spring Boot projects

### DIFF
--- a/section-12-spring-boot-3-quick-start/01-spring-boot-demo/.gitattributes
+++ b/section-12-spring-boot-3-quick-start/01-spring-boot-demo/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-13-spring-boot-3-rest-apis-quick-start/01-spring-boot-rest-crud-hello-world/.gitattributes
+++ b/section-13-spring-boot-3-rest-apis-quick-start/01-spring-boot-rest-crud-hello-world/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-13-spring-boot-3-rest-apis-quick-start/02-spring-boot-rest-crud-students-list-base/.gitattributes
+++ b/section-13-spring-boot-3-rest-apis-quick-start/02-spring-boot-rest-crud-students-list-base/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-13-spring-boot-3-rest-apis-quick-start/03-spring-boot-rest-crud-students-list-refactored/.gitattributes
+++ b/section-13-spring-boot-3-rest-apis-quick-start/03-spring-boot-rest-crud-students-list-refactored/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-13-spring-boot-3-rest-apis-quick-start/04-spring-boot-rest-crud-students-path-variable-get-single-student/.gitattributes
+++ b/section-13-spring-boot-3-rest-apis-quick-start/04-spring-boot-rest-crud-students-path-variable-get-single-student/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-14-spring-boot-3-spring-mvc-quick-start/01-thymeleafdemo-helloworld/.gitattributes
+++ b/section-14-spring-boot-3-spring-mvc-quick-start/01-thymeleafdemo-helloworld/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-14-spring-boot-3-spring-mvc-quick-start/02-thymeleafdemo-helloworld-css/.gitattributes
+++ b/section-14-spring-boot-3-spring-mvc-quick-start/02-thymeleafdemo-helloworld-css/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf


### PR DESCRIPTION
## Summary

Adds `.gitattributes` files to all 7 Spring Boot projects to ensure consistent line endings for Maven wrapper scripts across platforms.

## Changes

- Added `.gitattributes` to section-12-spring-boot-3-quick-start/01-spring-boot-demo
- Added `.gitattributes` to section-13-spring-boot-3-rest-apis-quick-start/01-spring-boot-rest-crud-hello-world
- Added `.gitattributes` to section-13-spring-boot-3-rest-apis-quick-start/02-spring-boot-rest-crud-students-list-base
- Added `.gitattributes` to section-13-spring-boot-3-rest-apis-quick-start/03-spring-boot-rest-crud-students-list-refactored
- Added `.gitattributes` to section-13-spring-boot-3-rest-apis-quick-start/04-spring-boot-rest-crud-students-path-variable-get-single-student
- Added `.gitattributes` to section-14-spring-boot-3-spring-mvc-quick-start/01-thymeleafdemo-helloworld
- Added `.gitattributes` to section-14-spring-boot-3-spring-mvc-quick-start/02-thymeleafdemo-helloworld-css

## Line Ending Configuration

```
/mvnw text eol=lf
*.cmd text eol=crlf
```

This ensures Maven wrapper scripts maintain correct line endings:
- Unix/Linux/macOS: LF for `mvnw`
- Windows: CRLF for `mvnw.cmd`