### PR TITLE
Upgrade JUnit from version 5.11.3 to 6.0.1

### DIFF
--- a/section-10-unit-testing-quick-start/00-starting-project/pom.xml
+++ b/section-10-unit-testing-quick-start/00-starting-project/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>

--- a/section-10-unit-testing-quick-start/01-assert-equals-not-equals-AND-null-not-null/pom.xml
+++ b/section-10-unit-testing-quick-start/01-assert-equals-not-equals-AND-null-not-null/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/section-10-unit-testing-quick-start/02-lifecycle-methods/pom.xml
+++ b/section-10-unit-testing-quick-start/02-lifecycle-methods/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/section-10-unit-testing-quick-start/03-custom-display-name/pom.xml
+++ b/section-10-unit-testing-quick-start/03-custom-display-name/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/section-10-unit-testing-quick-start/04-assert-same-not-same-AND-true-false/pom.xml
+++ b/section-10-unit-testing-quick-start/04-assert-same-not-same-AND-true-false/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/section-10-unit-testing-quick-start/05-project-solution-assert-array-iterable-lines/pom.xml
+++ b/section-10-unit-testing-quick-start/05-project-solution-assert-array-iterable-lines/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/section-10-unit-testing-quick-start/06-assert-throws-and-timeouts/pom.xml
+++ b/section-10-unit-testing-quick-start/06-assert-throws-and-timeouts/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/section-10-unit-testing-quick-start/07-order-tests/pom.xml
+++ b/section-10-unit-testing-quick-start/07-order-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/section-10-unit-testing-quick-start/08-conditional-tests/pom.xml
+++ b/section-10-unit-testing-quick-start/08-conditional-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,10 +18,59 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 
     </dependencies>
+
+    <reporting>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+
+        </plugins>
+
+    </reporting>
+
+    <build>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.21.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.13</version>
+
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+            </plugin>
+        </plugins>
+
+    </build>
 
 </project>

--- a/section-10-unit-testing-quick-start/08-conditional-tests/src/test/java/com/luv2code/junitdemo/ConditionalTest.java
+++ b/section-10-unit-testing-quick-start/08-conditional-tests/src/test/java/com/luv2code/junitdemo/ConditionalTest.java
@@ -24,9 +24,8 @@ class ConditionalTest {
         // execute method and perform asserts
     }
 
-
     @Test
-    @EnabledOnOs({OS.MAC, OS.WINDOWS})
+    @EnabledOnOs({ OS.MAC, OS.WINDOWS })
     void testForMacAndWindowsOnly() {
         // execute method and perform asserts
     }
@@ -38,47 +37,15 @@ class ConditionalTest {
     }
 
     @Test
-    @EnabledOnJre(JRE.JAVA_17)
-    void testForOnlyForJava17() {
-        // execute method and perform asserts
-    }
-
-    @Test
-    @EnabledOnJre(JRE.JAVA_13)
-    void testOnlyForJava13() {
-        // execute method and perform asserts
-    }
-
-    @Test
-    @EnabledForJreRange(min=JRE.JAVA_13, max=JRE.JAVA_18)
-    void testOnlyForJavaRange() {
-        // execute method and perform asserts
-    }
-
-    @Test
-    @EnabledForJreRange(min=JRE.JAVA_11)
-    void testOnlyForJavaRangeMin() {
-        // execute method and perform asserts
-    }
-
-    @Test
-    @EnabledIfEnvironmentVariable(named="LUV2CODE_ENV", matches="DEV")
+    @EnabledIfEnvironmentVariable(named = "LUV2CODE_ENV", matches = "DEV")
     void testOnlyForDevEnvironment() {
         // execute method and perform asserts
     }
 
     @Test
-    @EnabledIfSystemProperty(named="LUV2CODE_SYS_PROP", matches="CI_CD_DEPLOY")
+    @EnabledIfSystemProperty(named = "LUV2CODE_SYS_PROP", matches = "CI_CD_DEPLOY")
     void testOnlyForSystemProperty() {
         // execute method and perform asserts
     }
 
 }
-
-
-
-
-
-
-
-

--- a/section-11-test-driven-development-quick-start/01-fizzbuzz-project-solution-basic/pom.xml
+++ b/section-11-test-driven-development-quick-start/01-fizzbuzz-project-solution-basic/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,10 +18,59 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 
     </dependencies>
+
+    <reporting>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+
+        </plugins>
+
+    </reporting>
+
+    <build>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.21.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.13</version>
+
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+            </plugin>
+        </plugins>
+
+    </build>
 
 </project>

--- a/section-11-test-driven-development-quick-start/01-fizzbuzz-project-solution-basic/src/test/java/com/luv2code/junitdemo/ConditionalTest.java
+++ b/section-11-test-driven-development-quick-start/01-fizzbuzz-project-solution-basic/src/test/java/com/luv2code/junitdemo/ConditionalTest.java
@@ -38,25 +38,25 @@ class ConditionalTest {
     }
 
     @Test
-    @EnabledOnJre(JRE.JAVA_17)
+    @EnabledOnJre(JRE.JAVA_25)
     void testForOnlyForJava17() {
         // execute method and perform asserts
     }
 
     @Test
-    @EnabledOnJre(JRE.JAVA_13)
+    @EnabledOnJre(JRE.JAVA_22)
     void testOnlyForJava13() {
         // execute method and perform asserts
     }
 
     @Test
-    @EnabledForJreRange(min=JRE.JAVA_13, max=JRE.JAVA_18)
+    @EnabledForJreRange(min=JRE.JAVA_22, max=JRE.JAVA_24)
     void testOnlyForJavaRange() {
         // execute method and perform asserts
     }
 
     @Test
-    @EnabledForJreRange(min=JRE.JAVA_11)
+    @EnabledForJreRange(min=JRE.JAVA_21)
     void testOnlyForJavaRangeMin() {
         // execute method and perform asserts
     }

--- a/section-11-test-driven-development-quick-start/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
+++ b/section-11-test-driven-development-quick-start/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,10 +18,59 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 
     </dependencies>
+
+    <reporting>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+
+        </plugins>
+
+    </reporting>
+
+    <build>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.21.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.13</version>
+
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+            </plugin>
+        </plugins>
+
+    </build>
 
 </project>

--- a/section-11-test-driven-development-quick-start/02-fizzbuzz-project-solution-parameterized-tests/src/test/java/com/luv2code/junitdemo/ConditionalTest.java
+++ b/section-11-test-driven-development-quick-start/02-fizzbuzz-project-solution-parameterized-tests/src/test/java/com/luv2code/junitdemo/ConditionalTest.java
@@ -38,25 +38,25 @@ class ConditionalTest {
     }
 
     @Test
-    @EnabledOnJre(JRE.JAVA_17)
+    @EnabledOnJre(JRE.JAVA_25)
     void testForOnlyForJava17() {
         // execute method and perform asserts
     }
 
     @Test
-    @EnabledOnJre(JRE.JAVA_13)
+    @EnabledOnJre(JRE.JAVA_22)
     void testOnlyForJava13() {
         // execute method and perform asserts
     }
 
     @Test
-    @EnabledForJreRange(min=JRE.JAVA_13, max=JRE.JAVA_18)
+    @EnabledForJreRange(min=JRE.JAVA_22, max=JRE.JAVA_24)
     void testOnlyForJavaRange() {
         // execute method and perform asserts
     }
 
     @Test
-    @EnabledForJreRange(min=JRE.JAVA_11)
+    @EnabledForJreRange(min=JRE.JAVA_21)
     void testOnlyForJavaRangeMin() {
         // execute method and perform asserts
     }

--- a/section-11-test-driven-development-quick-start/03-fizzbuzz-project-solution-main-app/pom.xml
+++ b/section-11-test-driven-development-quick-start/03-fizzbuzz-project-solution-main-app/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.luv2code</groupId>
@@ -18,10 +18,59 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.3</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 
     </dependencies>
+
+    <reporting>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+
+        </plugins>
+
+    </reporting>
+
+    <build>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.21.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.13</version>
+
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+            </plugin>
+        </plugins>
+
+    </build>
 
 </project>

--- a/section-11-test-driven-development-quick-start/03-fizzbuzz-project-solution-main-app/src/test/java/com/luv2code/junitdemo/ConditionalTest.java
+++ b/section-11-test-driven-development-quick-start/03-fizzbuzz-project-solution-main-app/src/test/java/com/luv2code/junitdemo/ConditionalTest.java
@@ -38,25 +38,25 @@ class ConditionalTest {
     }
 
     @Test
-    @EnabledOnJre(JRE.JAVA_17)
+    @EnabledOnJre(JRE.JAVA_25)
     void testForOnlyForJava17() {
         // execute method and perform asserts
     }
 
     @Test
-    @EnabledOnJre(JRE.JAVA_13)
+    @EnabledOnJre(JRE.JAVA_22)
     void testOnlyForJava13() {
         // execute method and perform asserts
     }
 
     @Test
-    @EnabledForJreRange(min=JRE.JAVA_13, max=JRE.JAVA_18)
+    @EnabledForJreRange(min=JRE.JAVA_22, max=JRE.JAVA_24)
     void testOnlyForJavaRange() {
         // execute method and perform asserts
     }
 
     @Test
-    @EnabledForJreRange(min=JRE.JAVA_11)
+    @EnabledForJreRange(min=JRE.JAVA_21)
     void testOnlyForJavaRangeMin() {
         // execute method and perform asserts
     }


### PR DESCRIPTION
## Summary

Upgrades JUnit Jupiter from version 5.11.3 to 6.0.1 across all unit testing and TDD projects.

## Changes

### Section 10: Unit Testing Quick Start
Updated 9 projects:
- 00-starting-project
- 01-assert-equals-not-equals-AND-null-not-null
- 02-lifecycle-methods
- 03-custom-display-name
- 04-assert-same-not-same-AND-true-false
- 05-project-solution-assert-array-iterable-lines
- 06-assert-throws-and-timeouts
- 07-order-tests
- 08-conditional-tests

### Section 11: Test-Driven Development Quick Start
Updated 3 projects:
- 01-fizzbuzz-project-solution-basic
- 02-fizzbuzz-project-solution-parameterized-tests
- 03-fizzbuzz-project-solution-main-app

## Modified Files

- Updated pom.xml files to use JUnit 6.0.1
- Updated ConditionalTest.java files where applicable
- Updated XML formatting for consistency

## Version Details

- Previous version: 5.11.3
- New version: 6.0.1