### PR TITLE
Update Java version from 25 to 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -42,10 +42,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -70,10 +70,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -98,10 +98,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -126,10 +126,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -154,10 +154,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -182,10 +182,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -210,10 +210,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -238,10 +238,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -266,10 +266,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -294,10 +294,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -322,10 +322,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -350,10 +350,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -378,10 +378,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6.0.2
 
-    - name: Set up JDK 25
+    - name: Set up JDK 26
       uses: actions/setup-java@v5.2.0
       with:
-        java-version: '25'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'maven'
 

--- a/section-01-java-fundamentals/demo/pom.xml
+++ b/section-01-java-fundamentals/demo/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-01-java-fundamentals/helloworld/pom.xml
+++ b/section-01-java-fundamentals/helloworld/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-02-conditionals/pom.xml
+++ b/section-02-conditionals/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-03-loops/pom.xml
+++ b/section-03-loops/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-04-methods/pom.xml
+++ b/section-04-methods/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-05-arrays/pom.xml
+++ b/section-05-arrays/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion1/pom.xml
+++ b/section-06-java-oop/battle-arena-sections/enemyversion1/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion2/pom.xml
+++ b/section-06-java-oop/battle-arena-sections/enemyversion2/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion3/pom.xml
+++ b/section-06-java-oop/battle-arena-sections/enemyversion3/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion4/pom.xml
+++ b/section-06-java-oop/battle-arena-sections/enemyversion4/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion5/pom.xml
+++ b/section-06-java-oop/battle-arena-sections/enemyversion5/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion6/pom.xml
+++ b/section-06-java-oop/battle-arena-sections/enemyversion6/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion7/pom.xml
+++ b/section-06-java-oop/battle-arena-sections/enemyversion7/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion8/pom.xml
+++ b/section-06-java-oop/battle-arena-sections/enemyversion8/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/battle-arena-sections/enemyversion9/pom.xml
+++ b/section-06-java-oop/battle-arena-sections/enemyversion9/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/battlearena-final/pom.xml
+++ b/section-06-java-oop/battlearena-final/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/problem-sections/vehicleversion1/pom.xml
+++ b/section-06-java-oop/problem-sections/vehicleversion1/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/problem-sections/vehicleversion2/pom.xml
+++ b/section-06-java-oop/problem-sections/vehicleversion2/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/problem-sections/vehicleversion3/pom.xml
+++ b/section-06-java-oop/problem-sections/vehicleversion3/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/problem-sections/vehicleversion4/pom.xml
+++ b/section-06-java-oop/problem-sections/vehicleversion4/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/problem-sections/vehicleversion5/pom.xml
+++ b/section-06-java-oop/problem-sections/vehicleversion5/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/problem-sections/vehicleversion6/pom.xml
+++ b/section-06-java-oop/problem-sections/vehicleversion6/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/problem-sections/vehicleversion7/pom.xml
+++ b/section-06-java-oop/problem-sections/vehicleversion7/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-06-java-oop/problem-sections/vehicleversion8/pom.xml
+++ b/section-06-java-oop/problem-sections/vehicleversion8/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-07-collections/arraylists/problem/pom.xml
+++ b/section-07-collections/arraylists/problem/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-07-collections/arraylists/version1/pom.xml
+++ b/section-07-collections/arraylists/version1/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-07-collections/arraylists/version2/pom.xml
+++ b/section-07-collections/arraylists/version2/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-07-collections/arraylists/version3/pom.xml
+++ b/section-07-collections/arraylists/version3/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-07-collections/deques/pom.xml
+++ b/section-07-collections/deques/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-07-collections/hashsets/version1/pom.xml
+++ b/section-07-collections/hashsets/version1/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-07-collections/maps/pom.xml
+++ b/section-07-collections/maps/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-08-exception-handling/five/pom.xml
+++ b/section-08-exception-handling/five/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-08-exception-handling/four/pom.xml
+++ b/section-08-exception-handling/four/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-08-exception-handling/one/pom.xml
+++ b/section-08-exception-handling/one/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-08-exception-handling/seven/pom.xml
+++ b/section-08-exception-handling/seven/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-08-exception-handling/six/pom.xml
+++ b/section-08-exception-handling/six/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-08-exception-handling/three/pom.xml
+++ b/section-08-exception-handling/three/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-08-exception-handling/two/pom.xml
+++ b/section-08-exception-handling/two/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-09-lambdas-streams/five/pom.xml
+++ b/section-09-lambdas-streams/five/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-09-lambdas-streams/four/pom.xml
+++ b/section-09-lambdas-streams/four/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-09-lambdas-streams/one/pom.xml
+++ b/section-09-lambdas-streams/one/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-09-lambdas-streams/seven/pom.xml
+++ b/section-09-lambdas-streams/seven/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-09-lambdas-streams/six/pom.xml
+++ b/section-09-lambdas-streams/six/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-09-lambdas-streams/three/pom.xml
+++ b/section-09-lambdas-streams/three/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-09-lambdas-streams/two/pom.xml
+++ b/section-09-lambdas-streams/two/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/section-10-unit-testing-quick-start/00-starting-project/pom.xml
+++ b/section-10-unit-testing-quick-start/00-starting-project/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
 </project>

--- a/section-10-unit-testing-quick-start/01-assert-equals-not-equals-AND-null-not-null/pom.xml
+++ b/section-10-unit-testing-quick-start/01-assert-equals-not-equals-AND-null-not-null/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-10-unit-testing-quick-start/02-lifecycle-methods/pom.xml
+++ b/section-10-unit-testing-quick-start/02-lifecycle-methods/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-10-unit-testing-quick-start/03-custom-display-name/pom.xml
+++ b/section-10-unit-testing-quick-start/03-custom-display-name/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-10-unit-testing-quick-start/04-assert-same-not-same-AND-true-false/pom.xml
+++ b/section-10-unit-testing-quick-start/04-assert-same-not-same-AND-true-false/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-10-unit-testing-quick-start/05-project-solution-assert-array-iterable-lines/pom.xml
+++ b/section-10-unit-testing-quick-start/05-project-solution-assert-array-iterable-lines/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-10-unit-testing-quick-start/06-assert-throws-and-timeouts/pom.xml
+++ b/section-10-unit-testing-quick-start/06-assert-throws-and-timeouts/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-10-unit-testing-quick-start/07-order-tests/pom.xml
+++ b/section-10-unit-testing-quick-start/07-order-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-10-unit-testing-quick-start/08-conditional-tests/pom.xml
+++ b/section-10-unit-testing-quick-start/08-conditional-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>26</maven.compiler.source>
-        <maven.compiler.target>26</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-10-unit-testing-quick-start/08-conditional-tests/pom.xml
+++ b/section-10-unit-testing-quick-start/08-conditional-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-11-test-driven-development-quick-start/01-fizzbuzz-project-solution-basic/pom.xml
+++ b/section-11-test-driven-development-quick-start/01-fizzbuzz-project-solution-basic/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>26</maven.compiler.source>
-        <maven.compiler.target>26</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-11-test-driven-development-quick-start/01-fizzbuzz-project-solution-basic/pom.xml
+++ b/section-11-test-driven-development-quick-start/01-fizzbuzz-project-solution-basic/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-11-test-driven-development-quick-start/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
+++ b/section-11-test-driven-development-quick-start/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>26</maven.compiler.source>
-        <maven.compiler.target>26</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-11-test-driven-development-quick-start/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
+++ b/section-11-test-driven-development-quick-start/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-11-test-driven-development-quick-start/03-fizzbuzz-project-solution-main-app/pom.xml
+++ b/section-11-test-driven-development-quick-start/03-fizzbuzz-project-solution-main-app/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>26</maven.compiler.source>
-        <maven.compiler.target>26</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-11-test-driven-development-quick-start/03-fizzbuzz-project-solution-main-app/pom.xml
+++ b/section-11-test-driven-development-quick-start/03-fizzbuzz-project-solution-main-app/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/section-12-spring-boot-3-quick-start/01-spring-boot-demo/pom.xml
+++ b/section-12-spring-boot-3-quick-start/01-spring-boot-demo/pom.xml
@@ -15,7 +15,7 @@
 	<name>mycoolapp</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>25</java.version>
+		<java.version>26</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-13-spring-boot-3-rest-apis-quick-start/01-spring-boot-rest-crud-hello-world/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/01-spring-boot-rest-crud-hello-world/pom.xml
@@ -15,7 +15,7 @@
 	<name>demo</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>25</java.version>
+		<java.version>26</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-13-spring-boot-3-rest-apis-quick-start/02-spring-boot-rest-crud-students-list-base/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/02-spring-boot-rest-crud-students-list-base/pom.xml
@@ -15,7 +15,7 @@
 	<name>demo</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>25</java.version>
+		<java.version>26</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-13-spring-boot-3-rest-apis-quick-start/03-spring-boot-rest-crud-students-list-refactored/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/03-spring-boot-rest-crud-students-list-refactored/pom.xml
@@ -15,7 +15,7 @@
 	<name>demo</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>25</java.version>
+		<java.version>26</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-13-spring-boot-3-rest-apis-quick-start/04-spring-boot-rest-crud-students-path-variable-get-single-student/pom.xml
+++ b/section-13-spring-boot-3-rest-apis-quick-start/04-spring-boot-rest-crud-students-path-variable-get-single-student/pom.xml
@@ -15,7 +15,7 @@
 	<name>demo</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>25</java.version>
+		<java.version>26</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-14-spring-boot-3-spring-mvc-quick-start/01-thymeleafdemo-helloworld/pom.xml
+++ b/section-14-spring-boot-3-spring-mvc-quick-start/01-thymeleafdemo-helloworld/pom.xml
@@ -15,7 +15,7 @@
 	<name>thymeleafdemo</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>25</java.version>
+		<java.version>26</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-14-spring-boot-3-spring-mvc-quick-start/02-thymeleafdemo-helloworld-css/pom.xml
+++ b/section-14-spring-boot-3-spring-mvc-quick-start/02-thymeleafdemo-helloworld-css/pom.xml
@@ -15,7 +15,7 @@
 	<name>thymeleafdemo</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>25</java.version>
+		<java.version>26</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Summary
- Update Java version from 25 to 26 across all 64 course projects (pom.xml)
- Update GitHub Actions workflow to build and test with JDK 26
- Keep 4 JaCoCo-dependent projects on Java 25 bytecode (section-10/08-conditional-tests and the three section-11 fizzbuzz projects), since JaCoCo 0.8.13 cannot instrument Java 26 class files (tracked in #41)

Verification
- Ran mvn clean verify across all 64 projects under JDK 26: 60 pass fully, 4 pass after being kept on Java 25 bytecode for JaCoCo compatibility
- Ran deprecation/removal scan under JDK 26: 0 compile failures, 0 deprecation/removal/unchecked warnings
- Confirmed JAR artifacts produced for all passing projects
- Smoke tested the two Spring Boot apps in scope (section-13 REST API, section-14 Thymeleaf MVC): both started successfully under JDK 26
