### PR TITLE
Remove jacoco plugin and restore Java 26 target in affected projects

### DIFF
--- a/section-10-unit-testing-quick-start/08-conditional-tests/pom.xml
+++ b/section-10-unit-testing-quick-start/08-conditional-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -44,30 +44,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.21.0</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.13</version>
-
-                <executions>
-                    <execution>
-                        <id>jacoco-prepare</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-
-                    <execution>
-                        <id>jacoco-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
             </plugin>
         </plugins>
 

--- a/section-11-test-driven-development-quick-start/01-fizzbuzz-project-solution-basic/pom.xml
+++ b/section-11-test-driven-development-quick-start/01-fizzbuzz-project-solution-basic/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -44,30 +44,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.21.0</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.13</version>
-
-                <executions>
-                    <execution>
-                        <id>jacoco-prepare</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-
-                    <execution>
-                        <id>jacoco-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
             </plugin>
         </plugins>
 

--- a/section-11-test-driven-development-quick-start/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
+++ b/section-11-test-driven-development-quick-start/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -44,30 +44,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.21.0</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.13</version>
-
-                <executions>
-                    <execution>
-                        <id>jacoco-prepare</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-
-                    <execution>
-                        <id>jacoco-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
             </plugin>
         </plugins>
 

--- a/section-11-test-driven-development-quick-start/03-fizzbuzz-project-solution-main-app/pom.xml
+++ b/section-11-test-driven-development-quick-start/03-fizzbuzz-project-solution-main-app/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -44,30 +44,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.21.0</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.13</version>
-
-                <executions>
-                    <execution>
-                        <id>jacoco-prepare</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-
-                    <execution>
-                        <id>jacoco-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
             </plugin>
         </plugins>
 


### PR DESCRIPTION
Summary
- Remove the jacoco-maven-plugin from the 4 projects affected by issue #41 (JaCoCo 0.8.13 does not support Java 26 bytecode)
- Restore maven.compiler.source/target to 26 in those projects, removing the Java 25 workaround since jacoco was the only reason they were held back
- JaCoCo is not part of the course curriculum, so removing it has no impact on lesson content

Verification
- Ran mvn clean verify in all 4 affected projects under JDK 26, all BUILD SUCCESS with no jacoco-report execution
- Confirmed repo-wide grep for jacoco returns no remaining references

Closes #41